### PR TITLE
Fix mob and pet damageTypes

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -86,6 +86,7 @@ CBattleEntity::CBattleEntity()
     m_Immunity   = 0;
     isCharmed    = false;
     m_unkillable = false;
+    m_dmgType = (DAMAGETYPE)0;
 
     m_DeathType = DEATH_TYPE::NONE;
     BattleHistory.lastHitTaken_atkType = ATTACK_TYPE::NONE;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -86,7 +86,7 @@ CBattleEntity::CBattleEntity()
     m_Immunity   = 0;
     isCharmed    = false;
     m_unkillable = false;
-    m_dmgType = (DAMAGE_TYPE)0;
+    m_dmgType = DAMAGE_TYPE::NONE;
 
     m_DeathType = DEATH_TYPE::NONE;
     BattleHistory.lastHitTaken_atkType = ATTACK_TYPE::NONE;

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -86,7 +86,7 @@ CBattleEntity::CBattleEntity()
     m_Immunity   = 0;
     isCharmed    = false;
     m_unkillable = false;
-    m_dmgType = (DAMAGETYPE)0;
+    m_dmgType = (DAMAGE_TYPE)0;
 
     m_DeathType = DEATH_TYPE::NONE;
     BattleHistory.lastHitTaken_atkType = ATTACK_TYPE::NONE;

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -522,7 +522,7 @@ public:
 
     uint8 GetSpeed();
     
-    DAMAGETYPE m_dmgType;
+    DAMAGE_TYPE m_dmgType;
 
     bool isDead(); // проверяем, мертва ли сущность
     bool isAlive();

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -521,6 +521,8 @@ public:
     uint16 GetBaseRACC(uint8 skill, uint16 bonusSkill = 0);
 
     uint8 GetSpeed();
+    
+    DAMAGETYPE m_dmgType;
 
     bool isDead(); // проверяем, мертва ли сущность
     bool isAlive();

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1933,6 +1933,11 @@ namespace battleutils
         else
         {
             damageType = weapon ? weapon->getDmgType() : DAMAGE_TYPE::NONE;
+            
+            if ((PAttacker->objtype == TYPE_PET || (PAttacker->objtype == TYPE_MOB && PAttacker->isCharmed)) && PAttacker->PMaster->objtype == TYPE_PC)
+            {
+                damageType = PAttacker->m_dmgType == DAMAGE_TYPE::NONE ? DAMAGE_IMPACT : PAttacker->m_dmgType;
+            }
 
             if (isRanged)
             {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1936,7 +1936,7 @@ namespace battleutils
             
             if ((PAttacker->objtype == TYPE_PET || (PAttacker->objtype == TYPE_MOB && PAttacker->isCharmed)) && PAttacker->PMaster->objtype == TYPE_PC)
             {
-                damageType = PAttacker->m_dmgType == DAMAGE_TYPE::NONE ? DAMAGE_IMPACT : PAttacker->m_dmgType;
+                damageType = PAttacker->m_dmgType == DAMAGE_TYPE::NONE ? DAMAGE_TYPE::IMPACT : PAttacker->m_dmgType;
             }
 
             if (isRanged)

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -544,7 +544,6 @@ namespace petutils
         PMob->stats.CHR = (uint16)((fCHR + mCHR) * 0.9f);
         
         // Set damageType to impact (blunt) damage. All jugs at level 75 cap do blunt (impact) damage. https://ffxiclopedia.fandom.com/wiki/Category:Familiars
-        uint32 id = PMob->m_PetID;
         PMob->m_dmgType = DAMAGE_TYPE::IMPACT;
     }
 
@@ -1747,8 +1746,7 @@ namespace petutils
         PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, PPet->GetMLevel()));
         
         // Set damageType to slashing damage. "Wyverns do slashing damage..." https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)
-        uint32 id = PMob->m_PetID;
-        PMob->m_dmgType = DAMAGE_TYPE::SLASHING;
+        PPet->m_dmgType = DAMAGE_TYPE::SLASHING;
 
         // Job Point: Wyvern Max HP
         if (PMaster->objtype == TYPE_PC)

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -711,19 +711,23 @@ namespace petutils
             default: // case FRAME_HARLEQUIN:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(2, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(10, PPet->GetMLevel()));
+                PPet->m_dmgType = DAMAGE_IMPACT;
                 break;
             case FRAME_VALOREDGE:
                 PPet->m_Weapons[SLOT_SUB]->setShieldSize(3);
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(5, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(5, PPet->GetMLevel()));
+                PPet->m_dmgType = DAMAGE_SLASHING;
                 break;
             case FRAME_SHARPSHOT:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(1, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(11, PPet->GetMLevel()));
+                PPet->m_dmgType = DAMAGE_PIERCING;
                 break;
             case FRAME_STORMWAKER:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(10, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, PPet->GetMLevel()));
+                PPet->m_dmgType = DAMAGE_IMPACT;
                 break;
         }
 
@@ -883,6 +887,12 @@ namespace petutils
             PPet->addModifier(Mod::MACC, PMaster->getMod(Mod::PET_MACC_MEVA));
             PPet->addModifier(Mod::MEVA, PMaster->getMod(Mod::PET_MACC_MEVA));
         }
+        
+        // Set damage type for Avatars
+        if (PPet->m_PetID == PETID_CAIT_SITH || PPet->m_PetID == PETID_FENRIR)
+            PPet->m_dmgType = DAMAGE_SLASHING;
+        else
+            PPet->m_dmgType = DAMAGE_IMPACT;
     }
 
     /************************************************************************

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -542,6 +542,10 @@ namespace petutils
         PMob->stats.INT = (uint16)((fINT + mINT) * 0.9f);
         PMob->stats.MND = (uint16)((fMND + mMND) * 0.9f);
         PMob->stats.CHR = (uint16)((fCHR + mCHR) * 0.9f);
+        
+        // Set damageType to impact (blunt) damage. All jugs at level 75 cap do blunt (impact) damage. https://ffxiclopedia.fandom.com/wiki/Category:Familiars
+        uint32 id = PMob->m_PetID;
+        PMob->m_dmgType = DAMAGE_IMPACT;
     }
 
     void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats)
@@ -1731,6 +1735,10 @@ namespace petutils
         // Set D evasion and def
         PPet->setModifier(Mod::EVA, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, PPet->GetMLevel()));
         PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(SKILL_HAND_TO_HAND, JOB_WAR, PPet->GetMLevel()));
+        
+        // Set damageType to slashing damage. "Wyverns do slashing damage..." https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)
+        uint32 id = PMob->m_PetID;
+        PMob->m_dmgType = DAMAGE_SLASHING;
 
         // Job Point: Wyvern Max HP
         if (PMaster->objtype == TYPE_PC)

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -545,7 +545,7 @@ namespace petutils
         
         // Set damageType to impact (blunt) damage. All jugs at level 75 cap do blunt (impact) damage. https://ffxiclopedia.fandom.com/wiki/Category:Familiars
         uint32 id = PMob->m_PetID;
-        PMob->m_dmgType = DAMAGE_IMPACT;
+        PMob->m_dmgType = DAMAGE_TYPE::IMPACT;
     }
 
     void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats)
@@ -711,23 +711,23 @@ namespace petutils
             default: // case FRAME_HARLEQUIN:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(2, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(10, PPet->GetMLevel()));
-                PPet->m_dmgType = DAMAGE_IMPACT;
+                PPet->m_dmgType = DAMAGE_TYPE::IMPACT;
                 break;
             case FRAME_VALOREDGE:
                 PPet->m_Weapons[SLOT_SUB]->setShieldSize(3);
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(5, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(5, PPet->GetMLevel()));
-                PPet->m_dmgType = DAMAGE_SLASHING;
+                PPet->m_dmgType = DAMAGE_TYPE::SLASHING;
                 break;
             case FRAME_SHARPSHOT:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(1, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(11, PPet->GetMLevel()));
-                PPet->m_dmgType = DAMAGE_PIERCING;
+                PPet->m_dmgType = DAMAGE_TYPE::PIERCING;
                 break;
             case FRAME_STORMWAKER:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(10, PPet->GetMLevel());
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, PPet->GetMLevel()));
-                PPet->m_dmgType = DAMAGE_IMPACT;
+                PPet->m_dmgType = DAMAGE_TYPE::IMPACT;
                 break;
         }
 
@@ -890,9 +890,9 @@ namespace petutils
         
         // Set damage type for Avatars
         if (PPet->m_PetID == PETID_CAIT_SITH || PPet->m_PetID == PETID_FENRIR)
-            PPet->m_dmgType = DAMAGE_SLASHING;
+            PPet->m_dmgType = DAMAGE_TYPE::SLASHING;
         else
-            PPet->m_dmgType = DAMAGE_IMPACT;
+            PPet->m_dmgType = DAMAGE_TYPE::IMPACT;
     }
 
     /************************************************************************

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -887,7 +887,7 @@ namespace petutils
             PPet->addModifier(Mod::MEVA, PMaster->getMod(Mod::PET_MACC_MEVA));
         }
         
-        // Set damage type for Avatars
+        // Set damageType for Avatars
         if (PPet->m_PetID == PETID_CAIT_SITH || PPet->m_PetID == PETID_FENRIR)
             PPet->m_dmgType = DAMAGE_TYPE::SLASHING;
         else

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1748,7 +1748,7 @@ namespace petutils
         
         // Set damageType to slashing damage. "Wyverns do slashing damage..." https://www.bg-wiki.com/ffxi/Wyvern_(Dragoon_Pet)
         uint32 id = PMob->m_PetID;
-        PMob->m_dmgType = DAMAGE_SLASHING;
+        PMob->m_dmgType = DAMAGE_TYPE::SLASHING;
 
         // Job Point: Wyvern Max HP
         if (PMaster->objtype == TYPE_PC)

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -404,18 +404,18 @@ namespace zoneutils
 
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setMaxHit(1);
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setSkillType(sql->GetIntData(17));
-                    DAMAGETYPE damageType = DAMAGE_NONE;
+                    DAMAGE_TYPE damageType = DAMAGE_NONE;
                     switch (((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->getSkillType()) {
                     // Combat Skills
                     case SKILLTYPE::SKILL_NONE: 
-                        damageType = (DAMAGETYPE)0; 
+                        damageType = (DAMAGE_TYPE)0; 
                         break;
                     case SKILLTYPE::SKILL_ARCHERY:
                     case SKILLTYPE::SKILL_MARKSMANSHIP:
                     case SKILLTYPE::SKILL_THROWING:
                     case SKILLTYPE::SKILL_DAGGER: 
                     case SKILLTYPE::SKILL_POLEARM: 
-                        damageType = (DAMAGETYPE)1; 
+                        damageType = (DAMAGE_TYPE)1; 
                         break;
                     case SKILLTYPE::SKILL_SWORD:
                     case SKILLTYPE::SKILL_GREAT_SWORD:
@@ -424,14 +424,14 @@ namespace zoneutils
                     case SKILLTYPE::SKILL_SCYTHE: 
                     case SKILLTYPE::SKILL_KATANA:
                     case SKILLTYPE::SKILL_GREAT_KATANA: 
-                        damageType = (DAMAGETYPE)2; 
+                        damageType = (DAMAGE_TYPE)2; 
                         break;
                     case SKILLTYPE::SKILL_CLUB: 
                     case SKILLTYPE::SKILL_STAFF: 
-                        damageType = (DAMAGETYPE)3; 
+                        damageType = (DAMAGE_TYPE)3; 
                         break;
                     case SKILLTYPE::SKILL_HAND_TO_HAND: 
-                        damageType = (DAMAGETYPE)4; 
+                        damageType = (DAMAGE_TYPE)4; 
                         break;
                     default: break;
                 }

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -404,18 +404,18 @@ namespace zoneutils
 
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setMaxHit(1);
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setSkillType(sql->GetIntData(17));
-                    DAMAGE_TYPE damageType = DAMAGE_NONE;
+                    DAMAGE_TYPE damageType = DAMAGE_TYPE::NONE;
                     switch (((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->getSkillType()) {
                     // Combat Skills
                     case SKILLTYPE::SKILL_NONE: 
-                        damageType = (DAMAGE_TYPE)0; 
+                        damageType = DAMAGE_TYPE::NONE; 
                         break;
                     case SKILLTYPE::SKILL_ARCHERY:
                     case SKILLTYPE::SKILL_MARKSMANSHIP:
                     case SKILLTYPE::SKILL_THROWING:
                     case SKILLTYPE::SKILL_DAGGER: 
                     case SKILLTYPE::SKILL_POLEARM: 
-                        damageType = (DAMAGE_TYPE)1; 
+                        damageType = DAMAGE_TYPE::PIERCING; 
                         break;
                     case SKILLTYPE::SKILL_SWORD:
                     case SKILLTYPE::SKILL_GREAT_SWORD:
@@ -424,14 +424,14 @@ namespace zoneutils
                     case SKILLTYPE::SKILL_SCYTHE: 
                     case SKILLTYPE::SKILL_KATANA:
                     case SKILLTYPE::SKILL_GREAT_KATANA: 
-                        damageType = (DAMAGE_TYPE)2; 
+                        damageType = DAMAGE_TYPE::SLASHING; 
                         break;
                     case SKILLTYPE::SKILL_CLUB: 
                     case SKILLTYPE::SKILL_STAFF: 
-                        damageType = (DAMAGE_TYPE)3; 
+                        damageType = DAMAGE_TYPE::IMPACT; 
                         break;
                     case SKILLTYPE::SKILL_HAND_TO_HAND: 
-                        damageType = (DAMAGE_TYPE)4; 
+                        damageType = DAMAGE_TYPE::HTH; 
                         break;
                     default: break;
                 }

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -28,6 +28,7 @@
 
 #include "../campaign_system.h"
 #include "../conquest_system.h"
+#include "../entities/battleentity.h"
 #include "../entities/mobentity.h"
 #include "../entities/npcentity.h"
 #include "../items/item_weapon.h"
@@ -403,6 +404,39 @@ namespace zoneutils
 
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setMaxHit(1);
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setSkillType(sql->GetIntData(17));
+                    DAMAGETYPE damageType = DAMAGE_NONE;
+                    switch (((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->getSkillType()) {
+                    // Combat Skills
+                    case SKILLTYPE::SKILL_NONE: 
+                        damageType = (DAMAGETYPE)0; 
+                        break;
+                    case SKILLTYPE::SKILL_ARCHERY:
+                    case SKILLTYPE::SKILL_MARKSMANSHIP:
+                    case SKILLTYPE::SKILL_THROWING:
+                    case SKILLTYPE::SKILL_DAGGER: 
+                    case SKILLTYPE::SKILL_POLEARM: 
+                        damageType = (DAMAGETYPE)1; 
+                        break;
+                    case SKILLTYPE::SKILL_SWORD:
+                    case SKILLTYPE::SKILL_GREAT_SWORD:
+                    case SKILLTYPE::SKILL_AXE:
+                    case SKILLTYPE::SKILL_GREAT_AXE: 
+                    case SKILLTYPE::SKILL_SCYTHE: 
+                    case SKILLTYPE::SKILL_KATANA:
+                    case SKILLTYPE::SKILL_GREAT_KATANA: 
+                        damageType = (DAMAGETYPE)2; 
+                        break;
+                    case SKILLTYPE::SKILL_CLUB: 
+                    case SKILLTYPE::SKILL_STAFF: 
+                        damageType = (DAMAGETYPE)3; 
+                        break;
+                    case SKILLTYPE::SKILL_HAND_TO_HAND: 
+                        damageType = (DAMAGETYPE)4; 
+                        break;
+                    default: break;
+                }
+                ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDmgType(damageType);
+                
                     PMob->m_dmgMult = sql->GetUIntData(18);
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setDelay((sql->GetIntData(19) * 1000) / 60);
                     ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->setBaseDelay((sql->GetIntData(19) * 1000) / 60);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Converts all pet damage to impact/blunt damage rather than the current "None" they have set. Sets jugs to do impact damage and wyverns to do slashing damage. Mobs use damageTypes according to their weapon set in SQL (e.g. Polearm -> Piercing damage).

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Charm pet slimes on BST and throw them at different mobs and notice if the % physical damage taken reduction now works. Attack elementals with different pets and see if the damage is being reduced by the % damage reduction, etc.

<!-- Clear and detailed steps to test your changes here -->
