### PR TITLE
TH Multiplier Fix

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -887,7 +887,7 @@ void CMobEntity::DistributeRewards()
     }
 }
 
-int16 CMobEntity::ApplyTH(int16 m_THLvl, int16 rate)
+float CMobEntity::ApplyTH(int16 m_THLvl, int16 rate)
 {
     TracyZoneScoped;
 
@@ -960,7 +960,12 @@ int16 CMobEntity::ApplyTH(int16 m_THLvl, int16 rate)
     {
         if (m_THLvl < 3)
         {
-            multi = 1.00f + (0.20f * m_THLvl);
+            multi = 1.00f + (0.50f * m_THLvl);
+            return multi;
+        }
+        else if (m_THLvl < 5)
+        {
+            multi = 2.00f + (0.25f * (m_THLvl - 2));
             return multi;
         }
         else if (m_THLvl < 8)
@@ -1077,12 +1082,12 @@ int16 CMobEntity::ApplyTH(int16 m_THLvl, int16 rate)
         }
         else if (m_THLvl < 3)
         {
-            multi = 2.00f + (0.50f * (m_THLvl - 1));
+            multi = 2.00f + (0.34f * (m_THLvl - 1));
             return multi;
         }
         else if (m_THLvl < 5)
         {
-            multi = 2.50f + (0.16f * (m_THLvl - 2));
+            multi = 2.34f + (0.16f * (m_THLvl - 2));
             return multi;
         }
         else if (m_THLvl < 6)
@@ -1196,7 +1201,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
             for (int16 roll = 0; roll < maxRolls; ++roll)
             {
                 // Determine if this group should drop an item and determine bonus
-                int16 bonus = ApplyTH(m_THLvl, group.GroupRate);
+                float bonus = ApplyTH(m_THLvl, group.GroupRate);
                 if (group.GroupRate > 0 && xirand::GetRandomNumber(1000) < group.GroupRate * settings::get<float>("map.DROP_RATE_MULTIPLIER") * bonus)
                 {
                     // Each item in the group is given its own weight range which is the previous value to the previous value + item.DropRate
@@ -1224,7 +1229,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
         {
             for (int16 roll = 0; roll < maxRolls; ++roll)
             {
-                int16 bonus = ApplyTH(m_THLvl, item.DropRate);
+                float bonus = ApplyTH(m_THLvl, item.DropRate);
                 if (item.DropRate > 0 && xirand::GetRandomNumber(1000) < item.DropRate * settings::get<float>("map.DROP_RATE_MULTIPLIER") * bonus)
                 {
                     if (AddItemToPool(item.ItemID, ++dropCount))

--- a/src/map/entities/mobentity.h
+++ b/src/map/entities/mobentity.h
@@ -270,7 +270,7 @@ public:
 
 protected:
     void DistributeRewards();
-    int16 ApplyTH(int16 m_THLvl, int16 rate);
+    float ApplyTH(int16 m_THLvl, int16 rate);
     void DropItems(CCharEntity* PChar);
 
 private:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?
Corrected variable type for "bonus" variable in mobentity.cpp from an integer to a float. The ApplyTH() function returns a data type float, but the value was being stored in a int16 data type. This was causing decimal numbers to be floored (i.e 2.66 to 2).

Also corrected some of the calculations for TH multiply for TH1-4 for a few item rarity categories.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Tested changes on local server using printf to view bonus multiplier for TH, item drops, their rolls calculating drop chance, and the result of that.

Tested it with changing ApplyTH to return a float and stored in float var "bonus". Once "bonus" was changed to a float, the proper multiplier was being applied.
<!-- Clear and detailed steps to test your changes here -->
