### PR TITLE
fix sausage cooking quest cooldown

### DIFF
--- a/scripts/zones/South_Gustaberg/npcs/qm2.lua
+++ b/scripts/zones/South_Gustaberg/npcs/qm2.lua
@@ -19,7 +19,7 @@ entity.onTrade = function(player, npc, trade)
             -- player puts sheep meat on the fire
             player:messageSpecial(ID.text.FIRE_PUT, 4372)
             player:confirmTrade()
-            player:setCharVar("SGusta_Sausage_Timer", os.time() + 60) -- 1 minute earth time
+            player:setCharVar("SGusta_Sausage_Timer", os.time() + 3600) -- 1 game day
             player:needToZone(true)
         else
             -- message given if sheep meat is already on the fire


### PR DESCRIPTION
retail was originally 1 game day
was changed to 1 minute later 2016~
3600 seconds == 60*60== (1hour/1minute)*60

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [ ] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [ ] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
