### PR TITLE
Max chrRatio

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4931,8 +4931,8 @@ namespace battleutils
         const float levelRatio = (charmerBSTlevel - targetLvl) / 100.f;
         charmChance *= (1.f + levelRatio);
 
-        float chrRatio = ((PCharmer->CHR() - PTarget->CHR())) / 100.f;
-        charmChance *= (1.f * (chrRatio * 5.83));
+        float chrRatio = 1.f * ((((PCharmer->CHR() - PTarget->CHR())) / 100.f) * 5.83);
+        charmChance *= std::max(chrRatio, 1.f);
 
         // Retail doesn't take light/apollo into account for Gauge
         if (includeCharmAffinityAndChanceMods)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Makes bst able to charm at low levels and still has the benefit of making Chr matter too

Tested on level 4 mob easy prey was able to have 75%+
Tested on level 10 mob dc was able to have 50%+
Tested on level 11 EM mob was able to have 25%+
Tested on level 72 Tough Mob was able to have very difficult less than 25 become difficult greater than 25% with adding +12 chr
Tested on level 72 Even Match Difficult turned to might with +14 chr 
Tested on level 15 tough mob returned difficult to charm
    if (charmChance >= 75) then
        ability:setMsg(xi.msg.basic.SHOULD_BE_ABLE_CHARM)  -- The <player> should be able to charm <target>.
    elseif (charmChance >= 50) then
        ability:setMsg(xi.msg.basic.MIGHT_BE_ABLE_CHARM)   -- The <player> might be able to charm <target>.
    elseif (charmChance >= 25) then
        ability:setMsg(xi.msg.basic.DIFFICULT_TO_CHARM)    -- It would be difficult for the <player> to charm <target>.
    elseif (charmChance >= 1) then
        ability:setMsg(xi.msg.basic.VERY_DIFFICULT_CHARM)  -- It would be very difficult for the <player> to charm <target>.