### PR TITLE
Remove content tag from Mimas.

### DIFF
--- a/modules/era/sql/mob_groups_era.sql
+++ b/modules/era/sql/mob_groups_era.sql
@@ -481,7 +481,6 @@ UPDATE mob_groups SET minLevel='72',maxLevel='74' WHERE name='Viseclaw' AND grou
 -- Upper_Delkfutts_Tower (Zone 158)
 -- ------------------------------------------------------------
 
-UPDATE mob_groups SET content_tag='WOTG' WHERE name='Mimas' AND groupid='9' AND zoneid='158';
 UPDATE mob_groups SET content_tag='WOTG' WHERE name='Autarch' AND groupid='25' AND zoneid='158';
 
 -- ------------------------------------------------------------


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Mimas has WOTG content tag but there is history on the NM going back at least to 2004, I don't believe this NM should have any content tag.

## Steps to test these changes

