### PR TITLE
Add extra arrows in RNG AF quest.

### DIFF
--- a/scripts/zones/Xarcabard/npcs/qm6.lua
+++ b/scripts/zones/Xarcabard/npcs/qm6.lua
@@ -29,7 +29,7 @@ end
 entity.onEventFinish = function(player, csid, option)
     if csid == 6 then
         player:setCharVar("unbridledPassion", 6)
-    elseif csid == 7 and npcUtil.giveItem(player, xi.items.ICE_ARROW) then
+    elseif csid == 7 and npcUtil.giveItem(player, {{xi.items.ICE_ARROW, 99}}) then
         player:setCharVar("unbridledPassion", 7)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [ ] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

Add extra arrows in RNG AF quest.

