### PR TITLE
Update SOB6_Wild_Card.lua

### DIFF
--- a/scripts/quests/windurst/SOB6_Wild_Card.lua
+++ b/scripts/quests/windurst/SOB6_Wild_Card.lua
@@ -81,7 +81,7 @@ quest.sections =
             ['_6n2'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 2 then -- First meeting at house of hero.
+                    if quest:getVar(player, 'Prog') == 1 then -- First meeting at house of hero.
                         if player:getRank(xi.nation.WINDURST) < 9 then
                             return quest:progressEvent(386) -- Meet Joker.
                         else


### PR DESCRIPTION
changed line 84:

prog == 1 instead of prog==2, as 2 is never set. This should allow the quest to progress.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I have paid attention to this example and will edit again if need be to not break the formatting, or I will be ignored
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md)
- [x] I've _**tested my code and the things my code has changed**_ since the last commit in the PR, and will test after any later commits

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
The quest is BLOCKED because it is looking for prog to equal 2 but never SETS prog to 2. Instead I've changed the code to look for prog ==1 which it sets a few lines above.

## Steps to test these changes

Test changes will be to click on the "house of hero" door after it goes live and check to make sure the CS happens and we can progress with the quest.
<!-- Clear and detailed steps to test your changes here -->
